### PR TITLE
README.md: Switch images based on Github theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Hi there 👋, I'm Felipe Ferreira
 
 <p>
-    <!-- TODO: Change to the "mfelipe-logo-light.svg" when github allows image by themes: (dark, light...) -->
-    <img src="images/mfelipe-logo-grey.png" />
+<p>
+    <img src="images/mfelipe-logo-light.svg#gh-light-mode-only" />
+    <img src="images/mfelipe-logo-grey.png#gh-dark-mode-only" />
+</p>
 </p>
 <br/><br/>
 


### PR DESCRIPTION
It appears that Github (At least on my end) cannot load the .svg file containing the picture.

I'd recommend uploading the same file with .png extension and changing the README.md line accordingly; that alone should do the trick :)